### PR TITLE
skip checksum if null

### DIFF
--- a/src/actions/download-actions.js
+++ b/src/actions/download-actions.js
@@ -92,7 +92,9 @@ export class DownloadActions {
         if (fileTypes[file.name]) {
           config += `${file.link}\n`;
           config += `  dir=${run.name}\n`;
-          config += `  checksum=md5=${file.hash}\n\n`;
+          if (file.hash !== null) {
+            config += `  checksum=md5=${file.hash}\n\n`;
+          }
         }
       });
     });


### PR DESCRIPTION
Some files don't have a hash, the API will return a `null` hash for those. Aria2 cannot handle that, so skip adding it to the config.